### PR TITLE
udders no longer crash clients

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -118,9 +118,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
     {
         if (entity is not null)
         {
-            DebugTools.Assert(TryGetSolution(container, name, out var debugEnt)
-                              && debugEnt.Value.Owner == entity.Value.Owner);
-            return true;
+			return TryGetSolution(container, name, out var debugEnt) && debugEnt.Value.Owner == entity.Value.Owner;
         }
 
         return TryGetSolution(container, name, out entity);


### PR DESCRIPTION
## What this does
makes it so that udders don't use an assert call which normally would cause a client-side crash. pretty sure this is a debug build only thing.

## Why it's good
makes testing less annoying

## How it was tested
booted up server, no crash

**Changelog**
:cl:
- fix: Fixed a crash due to udders
